### PR TITLE
Add colander to benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently the following projects are benchmarked.
 * [Lollipop](http://lollipop.readthedocs.io/en/latest/)
 * [kim](http://kim.readthedocs.io/en/latest/)
 * [toasted-marshmallow](https://github.com/lyft/toasted-marshmallow)
+* [Colander](https://docs.pylonsproject.org/projects/colander/en/latest/)
 
 Along with a baseline custom function that doesn't use a framework.
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -2,10 +2,10 @@ import time
 from tabulate import tabulate
 from contextlib import contextmanager
 
-from subjects import (marsh, rf, serp, strain, hand, loli, k, lim, tmarsh)
+from subjects import (marsh, rf, serp, strain, col, hand, loli, k, lim, tmarsh)
 from data import ParentTestObject
 
-SUBJECTS = (marsh, rf, serp, strain, hand, loli, k, lim, tmarsh)
+SUBJECTS = (marsh, rf, serp, strain, col, hand, loli, k, lim, tmarsh)
 
 test_object = ParentTestObject()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 toastedmarshmallow==0.1.0
 serpy==0.1.1
+colander==1.4
 djangorestframework==3.6.3
 django==1.9
 pytest

--- a/subjects/col.py
+++ b/subjects/col.py
@@ -1,0 +1,111 @@
+import colander
+from colander import null
+
+__name__ = 'Colander'
+
+
+class ObjectType(colander.Mapping):
+    """
+    A colander type representing a generic python object
+    (uses colander mapping-based serialization).
+    """
+
+    def serialize(self, node, appstruct):
+        appstruct = appstruct.__dict__
+        return super(ObjectType, self).serialize(node, appstruct)
+
+    def deserialize(self, node, cstruct):
+        data = super(ObjectType, self).deserialize(node, cstruct)
+        appstruct = node.instance.__class__()
+        appstruct.__dict__.update(data)
+        return appstruct
+
+
+class ObjectSchema(colander.SchemaNode):
+    schema_type = ObjectType
+    instance = None
+
+    def serialize(self, appstruct):
+        if not self.instance:
+            # set the instance on all child schema nodes as they
+            # may need to access the instance environment
+            self.instance = appstruct
+            for subnode in self.children:
+                if isinstance(subnode, MethodSchema):
+                    setattr(subnode, 'instance', appstruct)
+        return super(ObjectSchema, self).serialize(appstruct)
+
+    def deserialize(self, cstruct):
+        appstruct = super(ObjectSchema, self).deserialize(cstruct)
+        if not self.instance:
+            self.instance = appstruct
+        return appstruct
+
+
+class CallableSchema(colander.SchemaNode):
+    def serialize(self, appstruct):
+        if appstruct is null:
+            return null
+        appstruct = appstruct()
+        return super(CallableSchema, self).serialize(appstruct)
+
+    def deserialize(self, cstruct):
+        if cstruct is null:
+            return null
+        appstruct = super(CallableSchema, self).deserialize(cstruct)
+        return lambda: appstruct
+
+
+class MethodSchema(CallableSchema):
+    def serialize(self, appstruct):
+        if appstruct is null:
+            appstruct = getattr(self.instance, self.name)
+        return super(MethodSchema, self).serialize(appstruct)
+
+
+class Differential(colander.SchemaNode):
+    def __init__(self, typ, differential=0):
+        self.differential = differential
+        super(Differential, self).__init__(typ)
+
+    def serialize(self, appstruct):
+        # operator could be overloaded by the appstruct class if necessary
+        appstruct += self.differential
+        return super(Differential, self).serialize(appstruct)
+
+    def deserialize(self, cstruct):
+        # operator could be overloaded by the appstruct class if necessary
+        appstruct = super(Differential, self).deserialize(cstruct)
+        appstruct -= self.differential
+        return appstruct
+
+
+class ChildSchema(ObjectSchema):
+    w = colander.SchemaNode(colander.Int())
+    y = colander.SchemaNode(colander.String())
+    x = Differential(colander.Int(), 10)
+    z = colander.SchemaNode(colander.Int())
+
+
+class ChildListSchema(colander.SequenceSchema):
+    sub = ChildSchema()
+
+
+class ParentSchema(ObjectSchema):
+    foo = colander.SchemaNode(colander.String())
+    bar = MethodSchema(colander.Int())
+    sub = ChildSchema()
+    subs = ChildListSchema()
+
+
+class ParentListSchema(colander.SequenceSchema):
+    parents = ParentSchema()
+
+
+unit_schema = ParentSchema()
+seq_schema = ParentListSchema()
+
+
+def serialization_func(obj, many):
+    schema = seq_schema if many else unit_schema
+    return schema.serialize(obj)

--- a/subjects/rf.py
+++ b/subjects/rf.py
@@ -10,7 +10,7 @@ __name__ = 'Django REST Framework'
 
 
 class SubRF(rf_serializers.Serializer):
-    w = rf_serializers.FloatField()
+    w = rf_serializers.IntegerField()
     x = rf_serializers.SerializerMethodField()
     y = rf_serializers.CharField()
     z = rf_serializers.IntegerField()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,4 +1,4 @@
-from subjects import rf, serp, strain, hand, loli, k, lim, tmarsh
+from subjects import rf, serp, strain, col, hand, loli, k, lim, tmarsh
 from data import ParentTestObject
 import pprint
 TARGET = {
@@ -32,22 +32,22 @@ TARGET = {
 def test_serializers():
     test_object = ParentTestObject()
 
-    for subject in (rf, tmarsh, serp, strain, hand, loli, k, lim):
+    for subject in (rf, tmarsh, serp, strain, col, hand, loli, k, lim):
         print(subject.__name__)
         data = subject.serialization_func(test_object, False)
         pprint.pprint(data)
-        assert data['foo'] == TARGET['foo']
-        assert data['bar'] == TARGET['bar']
-        assert data['sub']['w'] == TARGET['sub']['w']
-        assert data['subs'][3]['y'] == TARGET['subs'][3]['y']
-        assert data['subs'][3]['x'] == TARGET['subs'][3]['x']
+        assert str(data['foo']) == str(TARGET['foo'])
+        assert str(data['bar']) == str(TARGET['bar'])
+        assert str(data['sub']['w']) == str(TARGET['sub']['w'])
+        assert str(data['subs'][3]['y']) == str(TARGET['subs'][3]['y'])
+        assert str(data['subs'][3]['x']) == str(TARGET['subs'][3]['x'])
 
         datas = subject.serialization_func([test_object, test_object], True)
         for data in datas:
-            assert data['foo'] == TARGET['foo']
-            assert data['sub']['w'] == TARGET['sub']['w']
-            assert data['subs'][3]['y'] == TARGET['subs'][3]['y']
-            assert data['subs'][3]['x'] == TARGET['subs'][3]['x']
+            assert str(data['foo']) == str(TARGET['foo'])
+            assert str(data['sub']['w']) == str(TARGET['sub']['w'])
+            assert str(data['subs'][3]['y']) == str(TARGET['subs'][3]['y'])
+            assert str(data['subs'][3]['x']) == str(TARGET['subs'][3]['x'])
 
 if __name__ == '__main__':
     test_serializers()


### PR DESCRIPTION
# Summary

- adds colander to the benchmark
- fixes a bug in the Django REST Framework serializer which was serializing to Float instead of Int like the other serializers

# Details

I saw that Colander was originally present in the benchmark but was removed [here](https://github.com/voidfiles/python-serialization-benchmark/issues/2). Looks like the reason was that the original benchmark used deserialization instead of serialization unlike the other benchmarks.

The present implementation is more idiomatic for Colander and matches the behavior of the other serializers more closely, e.g. it uses the serialization mode as one would expect. Main considerations for this implementation are:
- colander serializes any structured data to _strings_ (and back again to rich structured data)
- colander does not include object serialization out of the box (it includes dict, sequence, various types)

With this in mind, I implemented a simple object serializer based on the underlying dict or "mapping" serializer provided by colander -- not sure if this is the best/fastest way to go about it but it got the job done. Unlike the original benchmark which used a single schema for both individual as well as "many" serialization, this uses an explicit `List` schema to handle the case of list-of-objects, since colander provides support for sequences. Since colander serializes all datatypes down to string, I modified the test to compare strings instead of the serialized value directly. Finally, the method serialization mapping to a transformed value during serialization was an unusual case, but to avoid hardcoding it I implemented a "differential" schema type which applies a configurable differential to the value during serialization (i.e. the desired behavior). This achieves parity with the other serializers as far as this benchmark is concerned.

# Results

Here are some sample results on my laptop:

```
Library                  Many Objects (seconds)    One Object (seconds)    Relative
---------------------  ------------------------  ----------------------  ----------
Custom                                0.0133791              0.00622797     1
lima                                  0.0132332              0.00700712     1.0323
serpy                                 0.0384707              0.0190289      2.9326
Strainer                              0.0632088              0.0322461      4.86839
Toasted Marshmallow                   0.0802276              0.0387671      6.06897
Colander                              0.257669               0.121389      19.3327
Lollipop                              0.352046               0.168928      26.5707
Marshmallow                           0.513083               0.265392      39.7038
kim                                   0.659796               0.318289      49.8843
Django REST Framework                 0.785251               0.564185      68.824
```

Thanks for making this benchmark available!
